### PR TITLE
BunLite V1 -> V2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .DS_Store
 *.SQLite
 foo.ts
+*.db
+*.*-shm
+*.*-wal

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # Finder (MacOS) folder config
 .DS_Store
 *.SQLite
+foo.ts

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ tests/
 tsconfig.json
 .gitignore
 publish.ts
+foo.ts

--- a/README.md
+++ b/README.md
@@ -50,10 +50,14 @@ type DatabaseSchema = {
 };
 
 // Initialize database with type-safe table names
-const db = new BunLiteDB<keyof DatabaseSchema, DatabaseSchema>(
+const db = new BunLiteDB<DatabaseSchema>(
   "mydb.SQLite",
   ["Users", "Posts"]
 );
+
+// Connect to an already existing database
+const db = new BunLiteDB("existingDB.db");
+// If no schema is provided, return types will fallback to unknown.
 
 // Create tables with type checking on column names and types
 db.createTable("Users", [
@@ -108,7 +112,7 @@ type Schema = {
   }
 };
 
-const db = new BunLiteDB<keyof Schema, Schema>(":memory:", ["Users"]);
+const db = new BunLiteDB<Schema>(":memory:", ["Users"]);
 
 // Fetch page 1 with 10 records per page
 const page1 = db.fetchRecordsWithPagination("Users", 1, 10);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bunlite-typed",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,13 @@ type OutputSchema<Columns> = {
 
 type TableNames<T> = keyof T & string;
 
-type DbOptions = ConstructorParameters<typeof Database>[1] & {
+type DbOptions = ConstructorParameters<typeof Database>[1] | {
+    /**
+     * Enables SQLite's WAL mode. Enabled by default.
+     *
+     * @type {boolean}
+     * @default true
+     */
     writeAheadLog: boolean;
 }
 
@@ -57,14 +63,16 @@ export default class BunLiteDB<Schema extends Record<string, Record<string, unkn
         const newOpts = typeof opts === "number" ? opts : {
             create: true,
             strict: true,
+            writeAheadLog: true,
             ...opts,
         };
 
-        const useWal: boolean = newOpts.writeAheadLog ?? true;
+        const useWal: boolean = typeof newOpts !== "number" ? newOpts.writeAheadLog ?? true : false;
 
         try {
             this.db = new Database(dbName, newOpts);
             if (useWal) {
+                console.log("foo!");
                 this.db.exec("PRAGMA journal_mode = WAL;");
             }
         } catch (error: any) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export default class BunLiteDB<Schema extends Record<string, Record<string, unkn
      * @throws {SQLError} If database cannot be opened or initialized
      */
     constructor(
-        dbName: `${string}.SQLite` | ":memory:",
+        dbName: ":memory:" | (string & {}),
         tableNames?: TableNames<Schema>[],
         opts?: DbOptions
     ) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,9 +51,9 @@ export default class BunLiteDB<Schema extends Record<string, Record<string, unkn
         opts?: ConstructorParameters<typeof Database>[1]
     ) {
         const newOpts = typeof opts === "number" ? opts : {
-            ...opts,
             create: true,
             strict: true,
+            ...opts,
         };
 
         try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ export default class BunLiteDB<Schema extends Record<string, Record<string, unkn
      * @private
      * @returns Array of table names
      */
-    private getExistingTableNames(): string[] {
+    private getExistingTableNames(): TableNames<Schema>[] {
         const query = `SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'`;
         const results = this.db.query(query).all() as { name: string }[];
         return results.map(row => row.name);

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,6 @@ export default class BunLiteDB<Schema extends Record<string, Record<string, unkn
         try {
             this.db = new Database(dbName, newOpts);
             if (useWal) {
-                console.log("foo!");
                 this.db.exec("PRAGMA journal_mode = WAL;");
             }
         } catch (error: any) {

--- a/tests/SQLiteIdentifier.test.ts
+++ b/tests/SQLiteIdentifier.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import BunLiteDB from "../src/index";
 
 describe("SQLite Identifier Validation", () => {
-    const db = new BunLiteDB<"test", { test: {} }>(":memory:", ["test"]);
+    const db = new BunLiteDB<{ test: {} }>(":memory:", ["test"]);
 
     // Test valid identifiers
     const validNames = [

--- a/tests/concurrent.test.ts
+++ b/tests/concurrent.test.ts
@@ -14,7 +14,7 @@ type ConcurrentTestSchema = {
 };
 
 describe("Concurrent Operations", () => {
-    let db: BunLiteDB<keyof ConcurrentTestSchema, ConcurrentTestSchema>;
+    let db: BunLiteDB<ConcurrentTestSchema>;
 
     beforeEach(() => {
         db = new BunLiteDB(":memory:", ["Counter", "Log"]);

--- a/tests/concurrent.test.ts
+++ b/tests/concurrent.test.ts
@@ -87,3 +87,77 @@ describe("Concurrent Operations", () => {
         });
     });
 });
+
+describe("Multi-Instance Concurrent Operations", () => {
+    const dbPath = "test_concurrent.db";
+    let instances: BunLiteDB<ConcurrentTestSchema>[] = [];
+
+    beforeEach(() => {
+        for (let i = 0; i < 3; i++) {
+            const db = new BunLiteDB<ConcurrentTestSchema>(dbPath, ["Counter", "Log"]);
+            if (i === 0) {
+                db.createTable("Counter", [
+                    { name: "id", type: "INTEGER PRIMARY KEY AUTOINCREMENT" },
+                    { name: "value", type: "INTEGER NOT NULL" }
+                ]);
+                db.createTable("Log", [
+                    { name: "id", type: "INTEGER PRIMARY KEY AUTOINCREMENT" },
+                    { name: "message", type: "TEXT NOT NULL" },
+                    { name: "timestamp", type: "INTEGER NOT NULL" }
+                ]);
+            }
+            instances.push(db);
+        }
+    });
+
+    afterEach(async () => {
+        instances.forEach(db => db.closeConnection());
+        instances = [];
+        try {
+            await Bun.file(dbPath).delete();
+        } catch (error) {
+            console.error("Failed to delete test database:", error);
+        }
+    });
+
+    test("concurrent writes from multiple instances", async () => {
+        const insertsPerInstance = 50;
+        const promises = instances.map((db, dbIndex) => {
+            return Promise.all(
+                Array(insertsPerInstance).fill(0).map((_, i) => {
+                    return new Promise<void>((resolve) => {
+                        db.insertRecord("Counter", { value: dbIndex * 1000 + i });
+                        resolve();
+                    });
+                })
+            );
+        });
+
+        await Promise.all(promises.flat());
+        const totalRecords = instances[0].fetchAllRecords("Counter");
+        expect(totalRecords.length).toBe(insertsPerInstance * instances.length);
+    });
+
+    test("concurrent reads and writes from multiple instances", async () => {
+        const operations = 30;
+        const promises = instances.map((db, dbIndex) => {
+            return Promise.all(
+                Array(operations).fill(0).map((_, i) => {
+                    return new Promise<void>((resolve) => {
+                        db.insertRecord("Log", {
+                            message: `Instance ${dbIndex} - Operation ${i}`,
+                            timestamp: Date.now()
+                        });
+                        const logs = db.fetchAllRecords("Log");
+                        expect(logs.length).toBeGreaterThan(0);
+                        resolve();
+                    });
+                })
+            );
+        });
+
+        await Promise.all(promises.flat());
+        const finalLogs = instances[0].fetchAllRecords("Log");
+        expect(finalLogs.length).toBe(operations * instances.length);
+    });
+});

--- a/tests/database.test.ts
+++ b/tests/database.test.ts
@@ -27,7 +27,7 @@ describe("SQLError", () => {
 });
 
 describe("BunLiteDB", () => {
-    let db: BunLiteDB<keyof TestSchema, TestSchema>;
+    let db: BunLiteDB<TestSchema>;
 
     beforeEach(() => {
         db = new BunLiteDB(":memory:", ["Users", "Posts"]);
@@ -40,6 +40,24 @@ describe("BunLiteDB", () => {
     test("database initialization", () => {
         expect(db).toBeDefined();
         expect(db.database).toBeDefined();
+    });
+
+    test("getExistingTableNames returns correct table names", () => {
+        db.createTable("Users", [
+            { name: "id", type: "INTEGER PRIMARY KEY AUTOINCREMENT" },
+            { name: "name", type: "TEXT NOT NULL" }
+        ]);
+
+        db.createTable("Posts", [
+            { name: "id", type: "INTEGER PRIMARY KEY AUTOINCREMENT" },
+            { name: "title", type: "TEXT NOT NULL" }
+        ]);
+
+        // @ts-ignore - accessing private method for testing
+        const tableNames = db.getExistingTableNames();
+        expect(tableNames).toContain("Users");
+        expect(tableNames).toContain("Posts");
+        expect(tableNames.length).toBe(2);
     });
 
     test("create table", () => {
@@ -68,8 +86,8 @@ describe("BunLiteDB", () => {
         const records = db.fetchAllRecords("Users");
         expect(records.length).toBe(1);
         const firstRecord = records[0];
-        expect(firstRecord?.name).toBe("Test User");
-        expect(firstRecord?.email).toBe("test@example.com");
+        expect(firstRecord.name).toBe("Test User");
+        expect(firstRecord.email).toBe("test@example.com");
     });
 
     test("upsert records", () => {
@@ -92,7 +110,7 @@ describe("BunLiteDB", () => {
         const records = db.fetchAllRecords("Users");
         expect(records.length).toBe(1);
         const firstRecord = records[0];
-        expect(firstRecord?.name).toBe("Updated User");
+        expect(firstRecord.name).toBe("Updated User");
     });
 
     test("fetch records with condition", () => {

--- a/tests/fuzz.test.ts
+++ b/tests/fuzz.test.ts
@@ -13,7 +13,7 @@ function generateValidTableName(): string {
 }
 
 describe("BunLiteDB Fuzz Tests", () => {
-    let db: BunLiteDB<string, Record<string, Record<string, unknown>>>;
+    let db: BunLiteDB<Record<string, Record<string, unknown>>>;
     let testTableNames: string[];
 
     beforeEach(() => {

--- a/tests/pagination.test.ts
+++ b/tests/pagination.test.ts
@@ -10,7 +10,7 @@ type TestSchema = {
 };
 
 describe("BunLiteDB Pagination", () => {
-    let db: BunLiteDB<keyof TestSchema, TestSchema>;
+    let db: BunLiteDB<TestSchema>;
 
     function createTestUsers(count: number): {
         name: string;

--- a/tests/performance.test.ts
+++ b/tests/performance.test.ts
@@ -37,7 +37,7 @@ function drawSpeedBar(recordsPerSec: number, color: string = "\x1b[32m", maxSpee
 }
 
 describe("Performance Tests", () => {
-    const db = new BunLiteDB<keyof TestSchema, TestSchema>(":memory:", ["PerformanceTest"]);
+    const db = new BunLiteDB<TestSchema>(":memory:", ["PerformanceTest"]);
 
     test("Bulk Insert Performance", async () => {
         const recordCounts = [1000, 10000, 100000];


### PR DESCRIPTION
Improved behind the scenes types and some public types too.

- The constructor only needs once type argument (the schema) instead of two now.
- Table names are optional, this allows for easier connections to existing SQLite files.
- Removed the .SQLite dbName extension enforcement.
- Added and improved testing, including more thorough concurrency testing.